### PR TITLE
Ensure script TS outputs

### DIFF
--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "noEmit": false,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- allow TypeScript emission for script builds

## Testing
- `npm run build:scripts` *(fails: Cannot find module 'puppeteer' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685820434060832896ad46ba046fffce