### PR TITLE
Add autoDeploy to cron job

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -67,6 +67,7 @@ services:
     name: ota-answer-hub-crawler
     runtime: node
     schedule: "0 2 * * *" # Runs daily at 2am UTC
+    autoDeploy: true
     buildCommand: |
       # Build timestamp: 2025-06-21-20:45:00 - Blueprint-ready build
       echo "Build started for comprehensive scraper..."


### PR DESCRIPTION
## Summary
- ensure Render redeploys the cron service on each commit by enabling `autoDeploy` in the cron job definition

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685820542ef083288177323526990135